### PR TITLE
Improve card UI with theme selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <h1>عيدك مبارك</h1>
     <p>أدخل اسمك لإنشاء بطاقة تهنئة خاصة بك</p>
 <input type="text" id="userName" placeholder="اكتب اسمك هنا" />
+<select id="themeSelect">
+  <option value="card">بطاقة العيد</option>
+  <option value="ramadan-card">بطاقة رمضان</option>
+</select>
 <br />
 <button id="generateBtn">أنشئ البطاقة</button>
   </div>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,17 @@
-// مسار صورة الخلفية
-const backgroundSrc = 'images/card.png';
+// اسم صورة الخلفية الافتراضية
+const defaultBackground = 'card';
 
 window.onload = () => {
     const generateBtn = document.getElementById('generateBtn');
     generateBtn.addEventListener('click', generateCard);
+
+    // تشغيل التوليد عند الضغط على Enter
+    const userNameInput = document.getElementById('userName');
+    userNameInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            generateCard();
+        }
+    });
 
     // زر المشاركة
     const shareBtn = document.getElementById('shareBtn');
@@ -20,11 +28,14 @@ async function generateCard() {
         return;
     }
 
+    const themeSelect = document.getElementById('themeSelect');
+    const selectedTheme = themeSelect ? themeSelect.value : defaultBackground;
+
     const canvas = document.getElementById('greetingCanvas');
     const ctx = canvas.getContext('2d');
 
     // تحميل خلفية البطاقة
-    const backgroundImage = await loadImage(backgroundSrc);
+    const backgroundImage = await loadImage(`images/${selectedTheme}.png`);
 
     // ضبط أبعاد الكانفاس لتطابق أبعاد الصورة
     canvas.width = backgroundImage.width;

--- a/style.css
+++ b/style.css
@@ -44,6 +44,21 @@ body {
   font-size: 16px; /* تأكد من أن الحجم لا يقل عن 16px */
 }
 
+/* اختيار التصميم */
+#themeSelect {
+  width: 50%;
+  max-width: 300px;
+  display: block;
+  margin: 0 auto 10px auto;
+  padding: 10px;
+  text-align: center;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  font-size: 16px;
+  background-color: #fff;
+  color: #000;
+}
+
 /* زر توليد البطاقة */
 #generateBtn {
   display: block;


### PR DESCRIPTION
## Summary
- add an option to choose between multiple card designs
- trigger card generation by pressing Enter
- style the new theme selector dropdown

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6857c0a26560832389ef6692cc756702